### PR TITLE
Feature/validate email with custom validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "phpmd/phpmd": "^2.15"
     },
     "require": {
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^1.11",
+        "egulias/email-validator": "^4"
     }
 }

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -15,16 +15,6 @@
             <property name="minimum" value="300" />
         </properties>
     </rule>
-    <rule ref="rulesets/codesize.xml/TooManyMethods">
-        <properties>
-            <property name="maxmethods" value="20" />
-        </properties>
-    </rule>
-    <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
-        <properties>
-            <property name="maxmethods" value="15" />
-        </properties>
-    </rule>
     <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
         <properties>
             <property name="maximum" value="100" />

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ This applies to these methods
 - `Assert::email`
 - `Assert::nullOrEmail`
 - `Assert::allEmail`
-- `Assert::allNulOrEmail`
+- `Assert::allNullOrEmail`
 
 
 Regular email assertion:

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ composer require ians/assert
 
 ## Usage
 
-See [webmozart/assert](https://github.com/webmozarts/assert) documentation about how to use Assertions.
+See [paqtcom/assert](https://github.com/webmozarts/assert) documentation about how to use Assertions.
 
 ## Improvements
 
@@ -39,3 +39,40 @@ It tells us:
 Expected a value equal to Ians\Assert\Tests\TestEnum::SecondCase. Got: Ians\Assert\Tests\TestEnum::FirstCase
 ```
 
+#### Custom email validation
+
+Default email assertions use PHP's `filter_var()` with `FILTER_VALIDATE_EMAIL`.
+
+
+All email assertions have an optional `$validation` argument to supply an alternative validation.
+All validations must be an implementation of the interface `Egulias\EmailValidator\Validation`.
+
+The Composer package [egulias/email-validator](https://github.com/egulias/EmailValidator) is used for this.
+
+Laravel uses this same package for email validation, its default email validator is `RFCValidation`, which allows for more formats than  `FILTER_VALIDATE_EMAIL`.
+
+
+This applies to these methods
+- `Assert::email`
+- `Assert::nullOrEmail`
+- `Assert::allEmail`
+- `Assert::allNulOrEmail`
+
+
+Regular email assertion:
+
+```php
+use Egulias\EmailValidator\Validation\RFCValidation;
+use PAQT\Assert\Assert;
+
+Assert::email('me@localhost'); // will throw an InvalidArgumentException due to missing top level domain
+```
+
+Custom validation email assertion:
+
+```php
+use Egulias\EmailValidator\Validation\RFCValidation;
+use PAQT\Assert\Assert;
+
+Assert::email('me@localhost', validation: RFCValidation::class); // will not throw an exception
+```

--- a/readme.md
+++ b/readme.md
@@ -13,14 +13,14 @@ To get started, you should add the the repo as a valid repository to your `compo
 ]
 ```
 
-Then you can install the `ians/assert` Composer dependency to your project:
+Then you can install the `paqtcom/assert` Composer dependency to your project:
 ```bash
-composer require ians/assert
+composer require paqtcom/assert
 ```
 
 ## Usage
 
-See [paqtcom/assert](https://github.com/webmozarts/assert) documentation about how to use Assertions.
+See [webmozart/assert](https://github.com/webmozarts/assert) documentation about how to use Assertions.
 
 ## Improvements
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -39,7 +39,7 @@ class Assert extends WebmozartAssert
     }
 
     /** @param null|class-string<EmailValidation> $validation If none specified, FILTER_VALIDATE_EMAIL is used. */
-    public static function nullOrEmail($value, $message = '', ?string $validation = null)
+    public static function nullOrEmail($value, $message = '', ?string $validation = null): void
     {
         null === $value || static::email($value, $message, $validation);
     }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PAQT\Assert;
 
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\EmailValidation;
 use Webmozart\Assert\Assert as WebmozartAssert;
 
 class Assert extends WebmozartAssert
@@ -15,5 +17,51 @@ class Assert extends WebmozartAssert
         }
 
         return parent::valueToString($value);
+    }
+
+    /** @param null|class-string<EmailValidation> $validation If none specified, FILTER_VALIDATE_EMAIL is used. */
+    public static function email($value, $message = '', ?string $validation = null): void
+    {
+        $message = $message ?: sprintf(
+            'Expected a value to be a valid e-mail address. Got: %s',
+            self::valueToString($value)
+        );
+        Assert::string($value, $message);
+
+        if ($validation === null) {
+            parent::email($value, $message);
+            return;
+        }
+
+        $validator = new EmailValidator();
+
+        Assert::true($validator->isValid($value, new $validation()), sprintf($message, self::valueToString($value)));
+    }
+
+    /** @param null|class-string<EmailValidation> $validation If none specified, FILTER_VALIDATE_EMAIL is used. */
+    public static function nullOrEmail($value, $message = '', ?string $validation = null)
+    {
+        null === $value || static::email($value, $message, $validation);
+    }
+
+    /** @param null|class-string<EmailValidation> $validation If none specified, FILTER_VALIDATE_EMAIL is used. */
+    public static function allEmail($value, $message = '', ?string $validation = null): void
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::email($entry, $message, $validation);
+        }
+    }
+
+    /** @param null|class-string<EmailValidation> $validation If none specified, FILTER_VALIDATE_EMAIL is used. */
+
+    public static function allNullOrEmail($value, $message = '', ?string $validation = null): void
+    {
+        static::isIterable($value);
+
+        foreach ($value as $entry) {
+            static::nullOrEmail($entry, $message, $validation);
+        }
     }
 }

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -44,6 +44,16 @@ class EmailTest extends TestCase
     }
 
     /** @test */
+    public function email_with_rfc_validation_accepts_local_name_of_any_length(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $email = str_repeat('x', 999) . '@domain.com';
+
+        Assert::email($email, validation: RFCValidation::class);
+    }
+
+    /** @test */
     public function email_accepts_domain_label_of_64_chars(): void
     {
         $this->expectNotToPerformAssertions();

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -91,7 +91,7 @@ class EmailTest extends TestCase
             sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $email)
         );
 
-        Assert::email($email);
+        Assert::email($email, validation: RFCValidation::class);
     }
 
     /** @test */
@@ -186,7 +186,6 @@ class EmailTest extends TestCase
     public function all_email_fails_on_first_failing_default_validation()
     {
         $validEmail = 'me@domain.com';
-
         $tooLongDomainLabel = str_repeat('x', 62);
         $domain = str_repeat($tooLongDomainLabel . '.', 4) . '.com';
         $this->assertEquals(256, strlen($domain));
@@ -198,9 +197,7 @@ class EmailTest extends TestCase
             sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $invalidEmail)
         );
 
-        Assert::nullOrEmail(null);
-        Assert::nullOrEmail($validEmail);
-        Assert::nullOrEmail($invalidEmail);
+        Assert::allEmail([$validEmail, $invalidEmail], validation: RFCValidation::class);
     }
 
     /** @test */

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -105,13 +105,13 @@ class EmailTest extends TestCase
     }
 
     /** @test */
-    public function email_fails_on_domain_exceeding_255_chars(): void
+    public function email_fails_on_email_exceeding_254_chars(): void
     {
-        $label = str_repeat('x', 62);
-        $domain = str_repeat($label . '.', 4) . '.com';
-        $this->assertEquals(256, strlen($domain));
+        $label = str_repeat('x', 40);
+        $domain = join('.', array_fill(0, 6, $label)) . '.com';
 
-        $email = 'me@' . $domain;
+        $email = 'local@' . $domain;
+        $this->assertEquals(255, strlen($email));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -122,14 +122,25 @@ class EmailTest extends TestCase
     }
 
     /** @test */
-    public function email_with_rfc_validation_fails_on_domain_exceeding_255_chars(): void
+    public function email_with_rfc_validation_accepts_email_exceeding_254_chars(): void
+    {
+        $label = str_repeat('x', 40);
+        $domain = join('.', array_fill(0, 6, $label)) . '.com';
+
+        $email = 'local@' . $domain;
+        $this->assertEquals(255, strlen($email));
+
+        Assert::email($email, validation: RFCValidation::class);
+    }
+
+    /** @test */
+    public function email_with_rfc_validation_fails_on_domain_exceeding_254_chars(): void
     {
         $label = str_repeat('x', 62);
-        $domain = str_repeat($label . '.', 4) . '.com';
-
-        $this->assertEquals(256, strlen($domain));
+        $domain = join('.', array_fill(0, 4, $label)) . '.nl';
 
         $email = 'me@' . $domain;
+        $this->assertEquals(254, strlen($domain));
 
         $this->expectExceptionMessage(
             sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $email)
@@ -198,7 +209,6 @@ class EmailTest extends TestCase
         $validEmail = 'me@domain.com';
         $tooLongDomainLabel = str_repeat('x', 62);
         $domain = str_repeat($tooLongDomainLabel . '.', 4) . '.com';
-        $this->assertEquals(256, strlen($domain));
 
         $invalidEmail = 'me@' . $domain;
 
@@ -216,8 +226,7 @@ class EmailTest extends TestCase
         $validEmails = ['me@domain.com', 'me@localhost'];
 
         $tooLongDomainLabel = str_repeat('x', 62);
-        $domain = str_repeat($tooLongDomainLabel . '.', 4) . '.com';
-        $this->assertEquals(256, strlen($domain));
+        $domain = join('.', array_fill(0, 4, $tooLongDomainLabel)) . '.com';
 
         $invalidEmail = 'me@' . $domain;
 
@@ -250,8 +259,6 @@ class EmailTest extends TestCase
 
         $tooLongDomainLabel = str_repeat('x', 62);
         $domain = str_repeat($tooLongDomainLabel . '.', 4) . '.com';
-        $this->assertEquals(256, strlen($domain));
-
         $invalidEmail = 'me@' . $domain;
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PAQT\Assert\Tests;
+
+use Egulias\EmailValidator\Validation\RFCValidation;
+use PAQT\Assert\Assert;
+use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\InvalidArgumentException;
+
+class EmailTest extends TestCase
+{
+    /** @test */
+    public function email_accepts_local_name_of_64_chars(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $email = str_repeat('x', 64) . '@test.com';
+
+        Assert::email($email);
+    }
+
+    /** @test */
+    public function email_with_rfc_validation_accepts_local_name_of_64_chars(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $email = str_repeat('x', 64) . '@test.com';
+
+        Assert::email($email, validation: RFCValidation::class);
+    }
+
+    /** @test */
+    public function email_fails_on_local_name_exceeding_64_chars(): void
+    {
+        $email = str_repeat('x', 65) . '@test.com';
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $email)
+        );
+
+        Assert::email($email);
+    }
+
+    /** @test */
+    public function email_accepts_domain_label_of_64_chars(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $domain = str_repeat('x', 63) . '.domain.com'; // dot is included in domain label count
+        $email = 'me@' . $domain;
+
+        Assert::email($email);
+    }
+
+    /** @test */
+    public function email_with_rfc_validation_accepts_domain_label_of_64_chars(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $domain = str_repeat('x', 63) . '.domain.com';
+        $email = 'me@' . $domain;
+
+        Assert::email($email, validation: RFCValidation::class);
+    }
+
+    /** @test */
+    public function email_fails_on_domain_label_exceeding_64_chars(): void
+    {
+        $domain = str_repeat('x', 64) . '.domain.com';
+        $email = 'me@' . $domain;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $email)
+        );
+
+        Assert::email($email);
+    }
+
+    /** @test */
+    public function email_with_rfc_validation_fails_on_domain_label_exceeding_64_chars(): void
+    {
+        $domain = str_repeat('x', 65) . '.domain.com';
+
+        $email = 'me@' . $domain;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $email)
+        );
+
+        Assert::email($email);
+    }
+
+    /** @test */
+    public function email_fails_on_domain_exceeding_255_chars(): void
+    {
+        $label = str_repeat('x', 62);
+        $domain = str_repeat($label . '.', 4) . '.com';
+        $this->assertEquals(256, strlen($domain));
+
+        $email = 'me@' . $domain;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $email)
+        );
+
+        Assert::email($email);
+    }
+
+    /** @test */
+    public function email_with_rfc_validation_fails_on_domain_exceeding_255_chars(): void
+    {
+        $label = str_repeat('x', 62);
+        $domain = str_repeat($label . '.', 4) . '.com';
+
+        $this->assertEquals(256, strlen($domain));
+
+        $email = 'me@' . $domain;
+
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $email)
+        );
+
+        Assert::email($email, validation: RFCValidation::class);
+    }
+
+    /** @test */
+    public function email_fails_on_email_without_top_level_domain(): void
+    {
+        $emailWithoutTopLevelDomain = 'me@localhost';
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $emailWithoutTopLevelDomain)
+        );
+
+        Assert::email($emailWithoutTopLevelDomain);
+    }
+
+    /** @test */
+    public function email_with_rfc_validation_accepts_email_without_top_level_domain(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $emailWithoutTopLevelDomain = 'to@localhost';
+        Assert::email($emailWithoutTopLevelDomain, validation: RFCValidation::class);
+    }
+
+    /** @test */
+    public function email_fails_on_non_string(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a value to be a valid e-mail address. Got: null');
+
+        Assert::email(null);
+    }
+
+    /** @test */
+    public function email_with_custom_validation_fails_on_non_string(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a value to be a valid e-mail address. Got: null');
+
+        Assert::email(null, validation: RFCValidation::class);
+    }
+
+    /** @test */
+    public function null_or_email_fails_on_failing_default_validation()
+    {
+        $validEmail = 'me@domain.com';
+        $invalidEmail = 'me@localhost';
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $invalidEmail)
+        );
+
+        Assert::nullOrEmail(null);
+        Assert::nullOrEmail($validEmail);
+        Assert::nullOrEmail($invalidEmail);
+    }
+
+    /** @test */
+    public function all_email_fails_on_first_failing_default_validation()
+    {
+        $validEmail = 'me@domain.com';
+
+        $tooLongDomainLabel = str_repeat('x', 62);
+        $domain = str_repeat($tooLongDomainLabel . '.', 4) . '.com';
+        $this->assertEquals(256, strlen($domain));
+
+        $invalidEmail = 'me@' . $domain;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $invalidEmail)
+        );
+
+        Assert::nullOrEmail(null);
+        Assert::nullOrEmail($validEmail);
+        Assert::nullOrEmail($invalidEmail);
+    }
+
+    /** @test */
+    public function all_email_with_custom_validation_fails_on_first_failing_provided_validation()
+    {
+        $validEmails = ['me@domain.com', 'me@localhost'];
+
+        $tooLongDomainLabel = str_repeat('x', 62);
+        $domain = str_repeat($tooLongDomainLabel . '.', 4) . '.com';
+        $this->assertEquals(256, strlen($domain));
+
+        $invalidEmail = 'me@' . $domain;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $invalidEmail)
+        );
+
+        Assert::allEmail([...$validEmails, $invalidEmail], validation: RFCValidation::class);
+    }
+
+    /** @test */
+    public function all_null_or_email_fails_on_first_failing_default_validation()
+    {
+        $validValues = [null, 'me@domain.com'];
+        $invalidEmail = 'me@localhost';
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $invalidEmail)
+        );
+
+        Assert::allNullOrEmail([...$validValues, $invalidEmail]);
+    }
+
+    /** @test */
+    public function all_null_or_email_with_custom_validation_fails_on_first_failing_provided_validation()
+    {
+        $validValues = [null, 'me@domain.com', 'me@localhost'];
+
+        $tooLongDomainLabel = str_repeat('x', 62);
+        $domain = str_repeat($tooLongDomainLabel . '.', 4) . '.com';
+        $this->assertEquals(256, strlen($domain));
+
+        $invalidEmail = 'me@' . $domain;
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $invalidEmail)
+        );
+
+        Assert::allNullOrEmail([...$validValues, $invalidEmail], validation: RFCValidation::class);
+    }
+}

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -16,7 +16,7 @@ class EmailTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $email = str_repeat('x', 64) . '@test.com';
+        $email = str_repeat('x', 64) . '@domain.com';
 
         Assert::email($email);
     }
@@ -26,7 +26,7 @@ class EmailTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $email = str_repeat('x', 64) . '@test.com';
+        $email = str_repeat('x', 64) . '@domain.com';
 
         Assert::email($email, validation: RFCValidation::class);
     }
@@ -34,7 +34,7 @@ class EmailTest extends TestCase
     /** @test */
     public function email_fails_on_local_name_exceeding_64_chars(): void
     {
-        $email = str_repeat('x', 65) . '@test.com';
+        $email = str_repeat('x', 65) . '@domain.com';
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             sprintf('Expected a value to be a valid e-mail address. Got: "%s"', $email)

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -9,7 +9,7 @@ use PAQT\Assert\Assert;
 use PHPUnit\Framework\TestCase;
 use Webmozart\Assert\InvalidArgumentException;
 
-class Test extends TestCase
+class EnumTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
resolves ian-paqt/assert#1

Voegt een afhankelijkheid van [egulias/email-validator](https://github.com/egulias/EmailValidator) toe.
Mag dus niet conflicteren met degene die Laravel gebruikt (in het geval van gebruiken in Laravel)

Zie changes in Readme en EmailTest.php wat het precies doet.
